### PR TITLE
Revert "Use master branch for gh-pages deployments"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
-          publish_branch: master


### PR DESCRIPTION
This reverts commit fbe230ede77cae494e19eb5e4b5151ee087c750a.